### PR TITLE
Directory.Build.props: Make folder properties overridable

### DIFF
--- a/source/Beached.sln
+++ b/source/Beached.sln
@@ -7,6 +7,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.props.default = Directory.Build.props.default
+		Directory.Build.props.user = Directory.Build.props.user
 		Directory.Build.targets = Directory.Build.targets
 	EndProjectSection
 EndProject

--- a/source/Beached/Beached.csproj
+++ b/source/Beached/Beached.csproj
@@ -53,7 +53,7 @@
 		</Reference>
 
 		<Reference Include="FUtility">
-		  <HintPath>D:\Modding\OxygenNotIncluded\Lib\FUtility.dll</HintPath>
+		  <HintPath>$(FUtilityPath)</HintPath>
 		</Reference>
 
 		<!--

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <SteamFolder>D:\Programs\Steam</SteamFolder>
-    <GameLibsFolder>$(SteamFolder)\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed</GameLibsFolder>
-    <PublicisedFolder>D:\Modding\OxygenNotIncluded\PublicisedLib</PublicisedFolder>
-    <ModFolder>$(UserProfile)\Documents\Klei\OxygenNotIncluded\mods\dev</ModFolder>
+    <Import Condition=" !Exists('Directory.Build.props.user') " Project="Directory.Build.props.default" />
+    <Import Condition=" Exists('Directory.Build.props.user') " Project="Directory.Build.props.user" />
+    
     <ClearOutputDirectory>True</ClearOutputDirectory>
     <Optimize>true</Optimize>
   </PropertyGroup>

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <SteamFolder>D:\Programs\Steam</SteamFolder>
-    <GameLibsFolder>$(SteamFolder)\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed</GameLibsFolder>
-    <PublicisedFolder>D:\Modding\OxygenNotIncluded\PublicisedLib</PublicisedFolder>
-    <ModFolder>$(UserProfile)\Documents\Klei\OxygenNotIncluded\mods\dev</ModFolder>
+  <Import Condition=" !Exists('Directory.Build.props.user') " Project="Directory.Build.props.default" />
+  <Import Condition=" Exists('Directory.Build.props.user') " Project="Directory.Build.props.user" />
+  
+  <PropertyGroup>    
     <ClearOutputDirectory>True</ClearOutputDirectory>
     <Optimize>true</Optimize>
   </PropertyGroup>

--- a/source/Directory.Build.props.default
+++ b/source/Directory.Build.props.default
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Instead of modifying this file, create a copy named Directory.Build.props.user and modify it to match the paths in your installation -->
+<Project>
+  <PropertyGroup>
+    <!--Steam Folder-->
+    <SteamFolder>D:\Programs\Steam</SteamFolder>
+    <!--Publicised Assembly Folder-->
+    <PublicisedFolder>D:\Modding\OxygenNotIncluded\PublicisedLib</PublicisedFolder>
+    <!--Gamedata Folder, adjust to your own ONI installation-->
+    <GameLibsFolder>$(SteamFolder)\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed</GameLibsFolder>
+    <!--OutputModFolder, adjust it to your own dev folder-->
+    <ModFolder>$(UserProfile)\Documents\Klei\OxygenNotIncluded\mods\dev</ModFolder>
+  </PropertyGroup>
+</Project>

--- a/source/Directory.Build.props.default
+++ b/source/Directory.Build.props.default
@@ -10,5 +10,7 @@
     <GameLibsFolder>$(SteamFolder)\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed</GameLibsFolder>
     <!--OutputModFolder, adjust it to your own dev folder-->
     <ModFolder>$(UserProfile)\Documents\Klei\OxygenNotIncluded\mods\dev</ModFolder>
+    <!--FUtilitiy Library Path-->
+    <FUtilityPath>D:\Modding\OxygenNotIncluded\Lib\FUtility.dll</FUtilityPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The GameLibsFolder and ModFolder properties need to be adjusted to match one's environment. But modifying Directory.Build.props results in the Git worktree being dirty, which prevents switching branches. To avoid this, place the default values for these properties inside a new Directory.Build.props.default file. The defaults are imported unless a Directory.Build.props.user file exists, in which case the per-user file gets imported instead. The per-user file is ignored by Git, which avoids dirtying the worktree.
